### PR TITLE
fix(keycard): pbkdf2_hmac the new pairing password

### DIFF
--- a/crates/keycard/src/application.rs
+++ b/crates/keycard/src/application.rs
@@ -554,9 +554,7 @@ where
         let cmd = match credential_type {
             CredentialType::Pin => ChangePinCommand::with_pin(new_value),
             CredentialType::Puk => ChangePinCommand::with_puk(new_value),
-            CredentialType::PairingSecret => {
-                ChangePinCommand::with_pairing_secret(new_value.as_bytes())
-            }
+            CredentialType::PairingSecret => ChangePinCommand::with_pairing_secret(new_value),
         };
 
         // Execute the command

--- a/crates/keycard/src/commands/pin.rs
+++ b/crates/keycard/src/commands/pin.rs
@@ -1,3 +1,4 @@
+use crate::crypto::generate_pairing_token;
 use bytes::{Bytes, BytesMut};
 use nexum_apdu_core::StatusWord;
 use nexum_apdu_globalplatform::constants::status::*;
@@ -73,8 +74,8 @@ apdu_pair! {
                 }
 
                 /// Create a CHANGE PAIRING SECRET command
-                pub fn with_pairing_secret(secret: &[u8]) -> Self {
-                    Self::new(0x02, 0x00).with_data(Bytes::copy_from_slice(secret))
+                pub fn with_pairing_secret(secret: &str) -> Self {
+                    Self::new(0x02, 0x00).with_data(generate_pairing_token(secret).to_vec())
                 }
             }
         }

--- a/crates/keycard/src/secure_channel.rs
+++ b/crates/keycard/src/secure_channel.rs
@@ -23,7 +23,7 @@ pub trait KeycardSecureChannelExt: CardTransport {
 
 impl<T: CardTransport> KeycardSecureChannelExt for KeycardSecureChannel<T> {
     fn pair(&mut self, password: &str) -> crate::Result<PairingInfo> {
-        self.pair(password).map_err(crate::Error::from)
+        self.pair(password)
     }
 }
 


### PR DESCRIPTION
This PR:

1. Now ensures that the new pairing password has it's pbkdf2_hmac applied, instead of requiring the user to do this :sweat_smile: 

Fixes #27 